### PR TITLE
Add rich terminal output formatting (issue #26)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@
 
 PLUGIN_PATH := $(shell pwd)
 PLUGIN_NAME := aida-github-plugin
+VENV := .venv/bin
 
 .PHONY: help lint lint-md lint-fix-md lint-yaml lint-frontmatter clean
 
@@ -30,19 +31,19 @@ lint-frontmatter: ## Validate frontmatter in Markdown files
 .PHONY: lint-py test format install
 
 lint-py: ## Run ruff linter on Python files
-	ruff check .
+	$(VENV)/ruff check .
 
 lint: lint-py lint-md lint-yaml lint-frontmatter ## Run all linters
 
 test: ## Run pytest
-	pytest tests/ -v
+	$(VENV)/pytest tests/ -v
 
 format: ## Auto-format Python code
-	ruff check . --fix
-	ruff format .
+	$(VENV)/ruff check . --fix
+	$(VENV)/ruff format .
 
 install: ## Install Python dependencies
-	pip install -e ".[dev]"
+	$(VENV)/pip install -e ".[dev]"
 
 clean: ## Remove build artifacts
 	find . -type d -name "__pycache__" -exec rm -rf {} + 2>/dev/null || true

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,13 @@
 
 PLUGIN_PATH := $(shell pwd)
 PLUGIN_NAME := aida-github-plugin
-VENV := .venv/bin
+
+# Use .venv/bin if it exists (local dev), otherwise use tools from PATH (CI)
+ifneq (,$(wildcard .venv/bin/python))
+  VENV_PREFIX := .venv/bin/
+else
+  VENV_PREFIX :=
+endif
 
 .PHONY: help lint lint-md lint-fix-md lint-yaml lint-frontmatter clean
 
@@ -31,19 +37,19 @@ lint-frontmatter: ## Validate frontmatter in Markdown files
 .PHONY: lint-py test format install
 
 lint-py: ## Run ruff linter on Python files
-	$(VENV)/ruff check .
+	$(VENV_PREFIX)ruff check .
 
 lint: lint-py lint-md lint-yaml lint-frontmatter ## Run all linters
 
 test: ## Run pytest
-	$(VENV)/pytest tests/ -v
+	$(VENV_PREFIX)pytest tests/ -v
 
 format: ## Auto-format Python code
-	$(VENV)/ruff check . --fix
-	$(VENV)/ruff format .
+	$(VENV_PREFIX)ruff check . --fix
+	$(VENV_PREFIX)ruff format .
 
 install: ## Install Python dependencies
-	$(VENV)/pip install -e ".[dev]"
+	$(VENV_PREFIX)pip install -e ".[dev]"
 
 clean: ## Remove build artifacts
 	find . -type d -name "__pycache__" -exec rm -rf {} + 2>/dev/null || true

--- a/docs/architecture/adr/008-rich-terminal-formatting.md
+++ b/docs/architecture/adr/008-rich-terminal-formatting.md
@@ -1,0 +1,126 @@
+---
+type: adr
+title: "ADR-008: Rich Terminal Output Formatting"
+status: accepted
+date: "2026-03-10"
+deciders:
+  - "oakensoul"
+context: Software
+tags: [architecture, output, formatting, accessibility]
+---
+
+# ADR-008: Rich Terminal Output Formatting
+
+**Status**: Accepted
+**Date**: 2026-03-10
+**Context**: Software
+
+## Context and Problem Statement
+
+The plugin's Python scripts produce plain-text output with no color, icons, or styling. Status messages
+like `ok: Created release v1.0.0` and `error: HTTP 404` are functional but hard to scan in a terminal
+full of other output. As the plugin grows to cover more GitHub operations, output readability becomes a
+cross-cutting concern that affects every script and handler.
+
+Key requirements:
+
+- Color coding for status categories (success/failure/warning/info)
+- Icons paired with text for accessibility (never color-only)
+- Graceful degradation when color is unavailable (`NO_COLOR`, non-TTY, `TERM=dumb`)
+- Shared library in `scripts/utils/` — not reimplemented per command
+
+## Decision Drivers
+
+- Accessibility: must work without color (icons + text always present)
+- Machine-readability: stdout is consumed by `--json` callers and piped to other tools
+- Backwards compatibility: existing callers of `print_table`, `print_success`, `print_error` must not break
+- Maintainability: avoid reimplementing ANSI handling, TTY detection, `NO_COLOR` support
+
+## Considered Options
+
+### Option A: Custom ANSI Escape Codes
+
+Write a small utility that wraps strings in ANSI escape sequences, with manual TTY detection.
+
+**Pros**: Zero dependencies, minimal code
+**Cons**: Must reimplement `NO_COLOR` support, `TERM=dumb` detection, Windows compatibility,
+Unicode width calculation. Ongoing maintenance burden for solved problems.
+
+### Option B: `colorama` + Custom Formatting
+
+Use `colorama` for cross-platform ANSI support, build tables and formatting on top.
+
+**Pros**: Lightweight dependency, good Windows support
+**Cons**: `colorama` only provides ANSI escape wrapping. Tables, status badges, and semantic
+styling must still be built from scratch.
+
+### Option C: `rich` Library (Chosen)
+
+Use the `rich` library for Console-based output with automatic TTY detection, `NO_COLOR` support,
+and semantic text styling.
+
+**Pros**: Handles TTY detection, `NO_COLOR`, `TERM=dumb`, Unicode width — all out of the box.
+Provides `Console`, `Text`, `Table`, and status spinners. De facto standard for Python CLI formatting.
+**Cons**: Medium-sized dependency (~50ms import time). Acceptable for CLI scripts that run once.
+
+## Decision Outcome
+
+**Chosen option**: Option C - `rich` library (`rich>=13.0,<14.0`)
+
+### Design Invariant: stdout Stays Plain
+
+This is the most important architectural decision. The plugin's output contract is:
+
+- **stdout** = machine-consumable data (`print_json`, `print_table`)
+- **stderr** = human-readable status messages (`print_success`, `print_error`, `die()`)
+
+**Rich formatting applies only to stderr.** The `print_table` and `print_json` functions remain
+unchanged — no Rich Console, no ANSI escapes, no color. This preserves the machine-readability
+contract established in ADR-001 and ensures scripts can be piped to `jq`, `grep`, or other tools.
+
+### Two-Stream Architecture
+
+A single `rich.console.Console(file=sys.stderr)` instance handles all stderr output. A fresh
+Console is created per call to ensure compatibility with pytest's `capsys` fixture (which swaps
+`sys.stderr`).
+
+### Icon + Text Accessibility
+
+Every colored message includes a Unicode icon so meaning is conveyed without relying on color:
+
+- `✔ ok: message` (green) — success
+- `✘ error: message` (red) — failure
+- `⚠ warning: message` (yellow) — warning
+- `ℹ message` (blue) — informational
+
+### Consequences
+
+**Positive**:
+
+- Status messages are immediately scannable in dense terminal output
+- `NO_COLOR` and non-TTY environments degrade gracefully (icons remain, color stripped)
+- Shared `style.py` constants ensure consistent color mapping across all scripts
+- New functions (`print_warning`, `print_info`, `print_status`, `print_diff_stat`,
+  `print_section`, `print_items`) provide a complete formatting vocabulary
+
+**Negative**:
+
+- Adds `rich` as a runtime dependency (alongside `jinja2`)
+- **Mitigation**: AIDA venv handles installation transparently
+- Console creation per call has minor overhead vs caching
+- **Mitigation**: Negligible for CLI scripts; required for test compatibility
+
+## Implementation Notes
+
+- `scripts/utils/style.py` — pure constants module (icons, status-color mappings)
+- `scripts/utils/output.py` — enhanced with Rich Console for stderr functions
+- `scripts/utils/errors.py` — `die()` uses Rich for colored error/hint output
+- Existing function signatures preserved — zero changes to calling scripts
+- `print_progress` (spinner) deferred to follow-up (no callers at launch)
+
+## References
+
+- [Rich documentation](https://rich.readthedocs.io/)
+- [NO_COLOR standard](https://no-color.org/)
+- ADR-001: Python Scripts for Deterministic Execution
+- Issue #26: Rich terminal output formatting and color coding

--- a/docs/architecture/adr/README.md
+++ b/docs/architecture/adr/README.md
@@ -13,6 +13,7 @@ This directory contains architecture decision records (ADRs) for the aida-github
 | [005](005-eighty-twenty-knowledge-model.md) | 80/20 Knowledge Model | Accepted | 2026-03-10 |
 | [006](006-aida-virtual-environment-for-scripts.md) | AIDA Virtual Environment for Scripts | Accepted | 2026-03-10 |
 | [007](007-three-tier-progressive-loading.md) | Three-Tier Progressive Loading | Accepted | 2026-03-10 |
+| [008](008-rich-terminal-formatting.md) | Rich Terminal Output Formatting | Accepted | 2026-03-10 |
 
 ## Categories
 
@@ -34,6 +35,10 @@ This directory contains architecture decision records (ADRs) for the aida-github
 
 - ADR-003: Config-Driven Workflows
 - ADR-006: AIDA Virtual Environment for Scripts
+
+### Output & Formatting
+
+- ADR-008: Rich Terminal Output Formatting
 
 ### Knowledge Management
 

--- a/issues/completed/issue-26/README.md
+++ b/issues/completed/issue-26/README.md
@@ -1,0 +1,79 @@
+---
+issue: 26
+title: "Rich terminal output formatting and color coding"
+status: "Completed"
+created: "2026-03-11 00:03:43"
+completed: "2026-03-10"
+pr: 83
+branch: "milestone-v0.2/feature/26-rich-terminal-output-formatting"
+---
+
+# Issue #26: Rich terminal output formatting and color coding
+
+**Status**: Completed
+**Labels**: enhancement, scripts
+**Milestone**: v0.2.0
+**Assignees**: oakensoul
+**PR**: [#83](https://github.com/oakensoul/aida-github-plugin/pull/83)
+
+## Description
+
+All plugin output displayed in Claude Code should be well-formatted,
+scannable, and use color/styling to aid readability. This is a
+cross-cutting concern that affects every handler.
+
+## Implementation Summary
+
+Added shared formatting utilities using the `rich` library with a
+two-stream architecture: stdout stays plain (machine-consumable),
+stderr gets rich formatting with icons and color.
+
+### Files Created
+
+- `scripts/utils/style.py` — 28 GitHub API state mappings, icons,
+  case-insensitive lookup
+- `docs/architecture/adr/008-rich-terminal-formatting.md` — design
+  decisions and stdout-plain invariant
+
+### Files Modified
+
+- `pyproject.toml` — added `rich>=13.0,<14.0`
+- `scripts/utils/output.py` — Rich Console for stderr, 8 new
+  functions (`print_warning`, `print_info`, `print_status`,
+  `print_diff_stat`, `print_section`, `print_items`, `_print_styled`,
+  `status_console`)
+- `scripts/utils/errors.py` — `die()` delegates to `print_error()`
+- `tests/test_scripts/test_utils.py` — 40 new tests (119 total)
+- `Makefile` — use `.venv/bin` for Python tools
+
+### Key Decisions
+
+- stdout stays plain (design invariant per ADR-008)
+- `rich` library for TTY detection, `NO_COLOR`, ANSI handling
+- Single `_STATUS_MAP` with NamedTuple (no duplicate dicts)
+- Case-insensitive `.lower()` lookup for GitHub API mixed casing
+- Per-call Console creation for pytest `capsys` compatibility
+- Icons always paired with text (accessibility)
+
+### Deferred
+
+- `print_progress` spinner (zero callers, deferred to follow-up)
+- Agent knowledge file updates for formatting utilities
+
+## Expert Reviews
+
+Two rounds by 4 agents (system-architect, tech-lead,
+claude-code-expert, github-expert). Round 2: all APPROVE,
+0 ERRORs, 0 WARNINGs.
+
+## Work Tracking
+
+- Branch: `milestone-v0.2/feature/26-rich-terminal-output-formatting`
+- Started: 2026-03-10
+- Completed: 2026-03-10
+- PR: #83
+
+## Related Links
+
+- [GitHub Issue](https://github.com/oakensoul/aida-github-plugin/issues/26)
+- [Pull Request](https://github.com/oakensoul/aida-github-plugin/pull/83)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ authors = [
 keywords = ["github", "devops", "ci-cd", "automation", "releases"]
 dependencies = [
     "jinja2>=3.1",
+    "rich>=13.0,<14.0",
 ]
 
 [tool.setuptools]

--- a/scripts/utils/errors.py
+++ b/scripts/utils/errors.py
@@ -6,6 +6,11 @@ import subprocess
 import sys
 from typing import NoReturn
 
+from rich.text import Text
+
+from .output import print_error, status_console
+from .style import ICON_INFO
+
 
 class ScriptError(Exception):
     """An error with an actionable hint for the user."""
@@ -48,13 +53,14 @@ def handle_gh_error(exc: subprocess.CalledProcessError) -> ScriptError:
 
 
 def die(error: ScriptError | str, *, code: int = 1) -> NoReturn:
-    """Print an error (and optional hint) to stderr, then exit."""
-    if isinstance(error, ScriptError):
-        print(f"error: {error}", file=sys.stderr)
-        if error.hint:
-            print(f"hint: {error.hint}", file=sys.stderr)
-    else:
-        print(f"error: {error}", file=sys.stderr)
+    """Print an error (and optional hint) to stderr with color, then exit."""
+    print_error(str(error))
+    if isinstance(error, ScriptError) and error.hint:
+        hint_text = Text()
+        hint_text.append(f"{ICON_INFO} ", style="yellow")
+        hint_text.append("hint: ", style="yellow bold")
+        hint_text.append(error.hint)
+        status_console().print(hint_text)
     sys.exit(code)
 
 

--- a/scripts/utils/output.py
+++ b/scripts/utils/output.py
@@ -1,10 +1,38 @@
-"""Output formatting utilities — JSON to stdout, status to stderr."""
+"""Output formatting utilities — JSON to stdout, rich status to stderr."""
 
 from __future__ import annotations
 
 import json
 import sys
 from typing import Any
+
+from rich.console import Console
+from rich.text import Text
+
+from .style import (
+    ICON_ERROR,
+    ICON_INFO,
+    ICON_SUCCESS,
+    ICON_WARNING,
+    status_style,
+)
+
+
+def status_console() -> Console:
+    """Create a Console for stderr (rich formatting when TTY).
+
+    A fresh Console is created each call so it always references the
+    current ``sys.stderr`` — important when pytest's capsys swaps it.
+
+    This function is part of the internal API shared across the utils
+    package (used by both output.py and errors.py).
+    """
+    return Console(file=sys.stderr, highlight=False)
+
+
+# ---------------------------------------------------------------------------
+# stdout functions — plain text, no color, no Rich (machine-consumable)
+# ---------------------------------------------------------------------------
 
 
 def print_json(data: Any) -> None:
@@ -13,7 +41,10 @@ def print_json(data: Any) -> None:
 
 
 def print_table(rows: list[dict[str, Any]], columns: list[str]) -> None:
-    """Print rows as an aligned text table to stdout."""
+    """Print rows as an aligned text table to stdout.
+
+    Column names are uppercased in the header automatically.
+    """
     if not rows:
         print("(no results)")
         return
@@ -32,11 +63,67 @@ def print_table(rows: list[dict[str, Any]], columns: list[str]) -> None:
         print(line)
 
 
+# ---------------------------------------------------------------------------
+# stderr functions — rich formatting with icons and color
+# ---------------------------------------------------------------------------
+
+
+def _print_styled(icon: str, prefix: str, style: str, message: str) -> None:
+    """Print a styled status message to stderr (icon + prefix + message)."""
+    text = Text()
+    text.append(f"{icon} ", style=style)
+    text.append(f"{prefix}: ", style=f"{style} bold")
+    text.append(message)
+    status_console().print(text)
+
+
 def print_success(message: str) -> None:
-    """Print a success message to stderr."""
-    print(f"ok: {message}", file=sys.stderr)
+    """Print a success message to stderr with green checkmark."""
+    _print_styled(ICON_SUCCESS, "ok", "green", message)
 
 
 def print_error(message: str) -> None:
-    """Print an error message to stderr."""
-    print(f"error: {message}", file=sys.stderr)
+    """Print an error message to stderr with red x-mark."""
+    _print_styled(ICON_ERROR, "error", "red", message)
+
+
+def print_warning(message: str) -> None:
+    """Print a warning message to stderr with yellow warning icon."""
+    _print_styled(ICON_WARNING, "warning", "yellow", message)
+
+
+def print_info(message: str) -> None:
+    """Print an info message to stderr with blue info icon."""
+    text = Text()
+    text.append(f"{ICON_INFO} ", style="blue")
+    text.append(message)
+    status_console().print(text)
+
+
+def print_status(label: str, value: str) -> None:
+    """Print a label: value pair to stderr, with value colored by status."""
+    text = Text()
+    text.append(f"{label}: ", style="bold")
+    text.append(value, style=status_style(value))
+    status_console().print(text)
+
+
+def print_diff_stat(additions: int, deletions: int) -> None:
+    """Print diff stats like '+42 -17' with green/red coloring to stderr."""
+    text = Text()
+    text.append(f"+{additions}", style="green")
+    text.append(" ")
+    text.append(f"-{deletions}", style="red")
+    status_console().print(text)
+
+
+def print_section(title: str) -> None:
+    """Print a section header (bold) to stderr."""
+    status_console().print(Text(title, style="bold"))
+
+
+def print_items(items: list[str], *, bullet: str = "-") -> None:
+    """Print a bulleted list to stderr."""
+    console = status_console()
+    for item in items:
+        console.print(f"  {bullet} {item}")

--- a/scripts/utils/style.py
+++ b/scripts/utils/style.py
@@ -1,0 +1,81 @@
+"""Style constants for rich terminal output — icons, colors, status mappings."""
+
+from __future__ import annotations
+
+from typing import NamedTuple
+
+# ---------------------------------------------------------------------------
+# Icons — Unicode symbols, always paired with text for accessibility
+# ---------------------------------------------------------------------------
+ICON_SUCCESS = "\u2714"  # ✔
+ICON_ERROR = "\u2718"  # ✘
+ICON_WARNING = "\u26a0"  # ⚠
+ICON_INFO = "\u2139"  # ℹ
+ICON_PENDING = "\u25cb"  # ○
+
+
+class _StatusEntry(NamedTuple):
+    style: str
+    icon: str
+
+
+# ---------------------------------------------------------------------------
+# Single source of truth: status → (rich style, icon)
+# Keys are lowercase — lookup functions normalize input via .lower()
+# ---------------------------------------------------------------------------
+_STATUS_MAP: dict[str, _StatusEntry] = {
+    # Success / positive
+    "success": _StatusEntry("green", ICON_SUCCESS),
+    "completed": _StatusEntry("green", ICON_SUCCESS),
+    "merged": _StatusEntry("green", ICON_SUCCESS),
+    "approved": _StatusEntry("green", ICON_SUCCESS),
+    "passing": _StatusEntry("green", ICON_SUCCESS),
+    # "open" is a GitHub API value; mapped green for PRs (positive).
+    # For issues "open" means unresolved — acceptable approximation.
+    "open": _StatusEntry("green", ICON_SUCCESS),
+    # Failure / negative
+    "failure": _StatusEntry("red", ICON_ERROR),
+    "error": _StatusEntry("red", ICON_ERROR),
+    "failed": _StatusEntry("red", ICON_ERROR),
+    "changes_requested": _StatusEntry("red", ICON_ERROR),
+    "conflicts": _StatusEntry("red", ICON_ERROR),
+    "closed": _StatusEntry("red", ICON_ERROR),
+    "cancelled": _StatusEntry("red", ICON_ERROR),
+    "timed_out": _StatusEntry("red", ICON_ERROR),
+    "startup_failure": _StatusEntry("red", ICON_ERROR),
+    # Warning / in-progress
+    "warning": _StatusEntry("yellow", ICON_WARNING),
+    "draft": _StatusEntry("yellow", ICON_PENDING),
+    "in_progress": _StatusEntry("yellow", ICON_PENDING),
+    "pending": _StatusEntry("yellow", ICON_PENDING),
+    "queued": _StatusEntry("yellow", ICON_PENDING),
+    "action_required": _StatusEntry("yellow", ICON_WARNING),
+    "stale": _StatusEntry("yellow", ICON_WARNING),
+    "requested": _StatusEntry("yellow", ICON_PENDING),
+    "waiting": _StatusEntry("yellow", ICON_PENDING),
+    "review_required": _StatusEntry("yellow", ICON_PENDING),
+    # Informational / neutral
+    "info": _StatusEntry("blue", ICON_INFO),
+    "skipped": _StatusEntry("dim", ICON_PENDING),
+    "neutral": _StatusEntry("dim", ICON_PENDING),
+    "dismissed": _StatusEntry("yellow", ICON_WARNING),
+    "commented": _StatusEntry("blue", ICON_INFO),
+}
+
+
+def status_style(status: str) -> str:
+    """Return the Rich style string for a status value, or 'default' if unknown.
+
+    Lookup is case-insensitive — handles GitHub API mixed casing automatically.
+    """
+    entry = _STATUS_MAP.get(status.lower())
+    return entry.style if entry else "default"
+
+
+def status_icon(status: str) -> str:
+    """Return the icon for a status value, or empty string if unknown.
+
+    Lookup is case-insensitive — handles GitHub API mixed casing automatically.
+    """
+    entry = _STATUS_MAP.get(status.lower())
+    return entry.icon if entry else ""

--- a/tests/test_scripts/test_utils.py
+++ b/tests/test_scripts/test_utils.py
@@ -7,7 +7,27 @@ import subprocess
 import pytest
 
 from scripts.utils.errors import ScriptError, die, handle_gh_error
-from scripts.utils.output import print_json, print_table
+from scripts.utils.output import (
+    print_diff_stat,
+    print_error,
+    print_info,
+    print_items,
+    print_json,
+    print_section,
+    print_status,
+    print_success,
+    print_table,
+    print_warning,
+)
+from scripts.utils.style import (
+    ICON_ERROR,
+    ICON_INFO,
+    ICON_PENDING,
+    ICON_SUCCESS,
+    ICON_WARNING,
+    status_icon,
+    status_style,
+)
 
 
 class TestScriptError:
@@ -93,6 +113,23 @@ class TestDie:
             die("usage error", code=2)
         assert exc_info.value.code == 2
 
+    def test_die_has_error_prefix(self, capsys: pytest.CaptureFixture[str]) -> None:
+        with pytest.raises(SystemExit):
+            die("something broke")
+        assert "error:" in capsys.readouterr().err
+
+    def test_die_has_hint_prefix(self, capsys: pytest.CaptureFixture[str]) -> None:
+        with pytest.raises(SystemExit):
+            die(ScriptError("failed", hint="do this"))
+        captured = capsys.readouterr().err
+        assert "hint:" in captured
+
+    def test_die_string_has_no_hint(self, capsys: pytest.CaptureFixture[str]) -> None:
+        with pytest.raises(SystemExit):
+            die("plain error")
+        captured = capsys.readouterr().err
+        assert "hint:" not in captured
+
 
 class TestOutput:
     """Test output formatting."""
@@ -113,3 +150,216 @@ class TestOutput:
         assert "NAME" in output
         assert "alice" in output
         assert "bob" in output
+
+    def test_print_table_has_separator(self, capsys: pytest.CaptureFixture[str]) -> None:
+        rows = [{"name": "alice"}]
+        print_table(rows, ["name"])
+        output = capsys.readouterr().out
+        assert "-----" in output
+
+
+class TestPrintSuccess:
+    """Test print_success with rich formatting."""
+
+    def test_contains_message(self, capsys: pytest.CaptureFixture[str]) -> None:
+        print_success("deployed")
+        assert "deployed" in capsys.readouterr().err
+
+    def test_contains_ok_prefix(self, capsys: pytest.CaptureFixture[str]) -> None:
+        print_success("done")
+        assert "ok:" in capsys.readouterr().err
+
+    def test_contains_icon(self, capsys: pytest.CaptureFixture[str]) -> None:
+        print_success("done")
+        assert ICON_SUCCESS in capsys.readouterr().err
+
+
+class TestPrintError:
+    """Test print_error with rich formatting."""
+
+    def test_contains_message(self, capsys: pytest.CaptureFixture[str]) -> None:
+        print_error("connection failed")
+        assert "connection failed" in capsys.readouterr().err
+
+    def test_contains_error_prefix(self, capsys: pytest.CaptureFixture[str]) -> None:
+        print_error("bad")
+        assert "error:" in capsys.readouterr().err
+
+    def test_contains_icon(self, capsys: pytest.CaptureFixture[str]) -> None:
+        print_error("bad")
+        assert ICON_ERROR in capsys.readouterr().err
+
+
+class TestPrintWarning:
+    """Test print_warning."""
+
+    def test_contains_message(self, capsys: pytest.CaptureFixture[str]) -> None:
+        print_warning("check this")
+        assert "check this" in capsys.readouterr().err
+
+    def test_contains_warning_prefix(self, capsys: pytest.CaptureFixture[str]) -> None:
+        print_warning("caution")
+        assert "warning:" in capsys.readouterr().err
+
+    def test_contains_icon(self, capsys: pytest.CaptureFixture[str]) -> None:
+        print_warning("caution")
+        assert ICON_WARNING in capsys.readouterr().err
+
+
+class TestPrintInfo:
+    """Test print_info."""
+
+    def test_contains_message(self, capsys: pytest.CaptureFixture[str]) -> None:
+        print_info("fetching data")
+        assert "fetching data" in capsys.readouterr().err
+
+    def test_contains_icon(self, capsys: pytest.CaptureFixture[str]) -> None:
+        print_info("note")
+        assert ICON_INFO in capsys.readouterr().err
+
+
+class TestPrintStatus:
+    """Test print_status label/value pairs."""
+
+    def test_contains_label_and_value(self, capsys: pytest.CaptureFixture[str]) -> None:
+        print_status("State", "merged")
+        captured = capsys.readouterr().err
+        assert "State:" in captured
+        assert "merged" in captured
+
+    def test_unknown_status_still_renders(self, capsys: pytest.CaptureFixture[str]) -> None:
+        print_status("State", "unknown_value")
+        captured = capsys.readouterr().err
+        assert "State:" in captured
+        assert "unknown_value" in captured
+
+
+class TestPrintDiffStat:
+    """Test print_diff_stat."""
+
+    def test_shows_additions_and_deletions(self, capsys: pytest.CaptureFixture[str]) -> None:
+        print_diff_stat(42, 17)
+        captured = capsys.readouterr().err
+        assert "+42" in captured
+        assert "-17" in captured
+
+    def test_zero_values(self, capsys: pytest.CaptureFixture[str]) -> None:
+        print_diff_stat(0, 0)
+        captured = capsys.readouterr().err
+        assert "+0" in captured
+        assert "-0" in captured
+
+
+class TestPrintSection:
+    """Test print_section."""
+
+    def test_contains_title(self, capsys: pytest.CaptureFixture[str]) -> None:
+        print_section("Pull Requests")
+        assert "Pull Requests" in capsys.readouterr().err
+
+
+class TestPrintItems:
+    """Test print_items bulleted list."""
+
+    def test_contains_items(self, capsys: pytest.CaptureFixture[str]) -> None:
+        print_items(["first", "second", "third"])
+        captured = capsys.readouterr().err
+        assert "first" in captured
+        assert "second" in captured
+        assert "third" in captured
+
+    def test_default_bullet(self, capsys: pytest.CaptureFixture[str]) -> None:
+        print_items(["item"])
+        assert "- item" in capsys.readouterr().err
+
+    def test_custom_bullet(self, capsys: pytest.CaptureFixture[str]) -> None:
+        print_items(["item"], bullet="*")
+        assert "* item" in capsys.readouterr().err
+
+    def test_empty_list(self, capsys: pytest.CaptureFixture[str]) -> None:
+        print_items([])
+        assert capsys.readouterr().err == ""
+
+
+class TestStyle:
+    """Test style.py constants and functions."""
+
+    # -- status_style --
+
+    def test_status_style_success(self) -> None:
+        assert status_style("success") == "green"
+        assert status_style("merged") == "green"
+
+    def test_status_style_failure(self) -> None:
+        assert status_style("failure") == "red"
+        assert status_style("error") == "red"
+
+    def test_status_style_warning(self) -> None:
+        assert status_style("warning") == "yellow"
+        assert status_style("draft") == "yellow"
+
+    def test_status_style_info(self) -> None:
+        assert status_style("info") == "blue"
+
+    def test_status_style_unknown(self) -> None:
+        assert status_style("nonexistent") == "default"
+
+    def test_status_style_case_insensitive(self) -> None:
+        assert status_style("MERGED") == "green"
+        assert status_style("Merged") == "green"
+        assert status_style("OPEN") == "green"
+        assert status_style("CLOSED") == "red"
+        assert status_style("DRAFT") == "yellow"
+        assert status_style("CHANGES_REQUESTED") == "red"
+
+    # -- status_icon --
+
+    def test_status_icon_success(self) -> None:
+        assert status_icon("success") == ICON_SUCCESS
+
+    def test_status_icon_failure(self) -> None:
+        assert status_icon("failure") == ICON_ERROR
+
+    def test_status_icon_warning(self) -> None:
+        assert status_icon("warning") == ICON_WARNING
+
+    def test_status_icon_pending(self) -> None:
+        assert status_icon("pending") == ICON_PENDING
+
+    def test_status_icon_info(self) -> None:
+        assert status_icon("info") == ICON_INFO
+
+    def test_status_icon_unknown(self) -> None:
+        assert status_icon("nonexistent") == ""
+
+    def test_status_icon_case_insensitive(self) -> None:
+        assert status_icon("MERGED") == ICON_SUCCESS
+        assert status_icon("OPEN") == ICON_SUCCESS
+        assert status_icon("CLOSED") == ICON_ERROR
+        assert status_icon("DRAFT") == ICON_PENDING
+        assert status_icon("CHANGES_REQUESTED") == ICON_ERROR
+
+    # -- GitHub API states coverage --
+
+    def test_github_workflow_states(self) -> None:
+        """Verify all GitHub workflow run states are mapped."""
+        assert status_style("cancelled") == "red"
+        assert status_style("timed_out") == "red"
+        assert status_style("action_required") == "yellow"
+        assert status_style("skipped") == "dim"
+        assert status_style("neutral") == "dim"
+        assert status_style("startup_failure") == "red"
+        assert status_style("requested") == "yellow"
+        assert status_style("waiting") == "yellow"
+
+    def test_github_review_states(self) -> None:
+        """Verify GitHub PR review states are mapped."""
+        assert status_style("approved") == "green"
+        assert status_style("changes_requested") == "red"
+        assert status_style("review_required") == "yellow"
+        assert status_style("dismissed") == "yellow"
+        assert status_style("commented") == "blue"
+
+    def test_draft_uses_pending_icon(self) -> None:
+        """Draft is a pending state, not a warning — uses circle icon."""
+        assert status_icon("draft") == ICON_PENDING


### PR DESCRIPTION
## Summary

- Add shared formatting utilities using the `rich` library for colored, icon-annotated status messages
- New `scripts/utils/style.py` with 28 GitHub API state mappings (case-insensitive)
- Enhanced `scripts/utils/output.py` with 8 new stderr functions (`print_warning`, `print_info`, `print_status`, `print_diff_stat`, `print_section`, `print_items`, plus `_print_styled` helper)
- Enhanced `scripts/utils/errors.py` — `die()` delegates to `print_error()` (DRY)
- ADR-008 documents the two-stream architecture: stdout stays plain, stderr gets rich formatting
- Makefile now uses `.venv/bin` for Python tools
- 119 tests pass (40 new for formatting, style, and GitHub state coverage)

## Design Decisions

- **stdout stays plain** (design invariant) — `print_table` and `print_json` unchanged, no ANSI escapes
- **stderr gets Rich** — icons + color for all status messages, respects `NO_COLOR` and non-TTY
- **Single `_STATUS_MAP`** — NamedTuple entries, case-insensitive `.lower()` lookup, no duplicate keys
- **`status_console()` per call** — fresh Console each invocation for pytest `capsys` compatibility
- **Accessibility** — every colored message includes a Unicode icon (never color-only)

## Expert Reviews

Two rounds of review by 4 agents (system-architect, tech-lead, claude-code-expert, github-expert):

| Round | Result |
|-------|--------|
| Round 1 | 3 REQUEST CHANGES, 1 APPROVE — 4 ERRORs, 13 WARNINGs |
| Round 2 | 4 APPROVE — 0 ERRORs, 0 WARNINGs (1 pre-existing Makefile fixed) |

Closes #26

## Test Plan

- [x] `make lint` passes (ruff, markdownlint, yamllint)
- [x] `make test` passes (119 tests, 0 failures)
- [x] Visual verification of colored output in terminal
- [x] `NO_COLOR=1` graceful degradation verified
- [x] All 6 existing scripts unmodified and working